### PR TITLE
The meta charset needs to be set at the beginning

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <html >
 
 	<head>
+		<meta charset="utf-8">
 		<title>H Campaign</title>
 
     	<link rel="stylesheet" type="text/css" href="style.css">
@@ -41,7 +42,6 @@
       <!-- Latest compiled and minified JavaScript -->
       <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
       <!-- D3 with geomap -->
-      <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
       <script type="text/javascript" src="d3-geomap/vendor/d3.geomap.dependencies.min.js"></script>
       <script type="text/javascript" src="d3-geomap/js/d3.geomap.js"></script>
       <!-- My JS -->


### PR DESCRIPTION
Took me a bit to find this, since it worked in my examples where the tag was set. Anyway, I'll add this to the documentation, also as a reminder for myself.

Changes:
Set meta charset so encoding of JS and topojson files causes no trouble.
Removed inclusion of d3.min.js as it is already included in the dependencies.